### PR TITLE
Fix webhooks showing as unk. and role colours for members being incorrect

### DIFF
--- a/src/main/scala/discordccc/DiscordChat.scala
+++ b/src/main/scala/discordccc/DiscordChat.scala
@@ -222,7 +222,7 @@ class DiscordChat extends BaseApplication with NavigationTree with ConnectorList
   protected def addMessage(message: Message): Unit = {
     val selectedChannel = selectedMessageChannel.get
     val connector = selectedChannel.connector
-    val user = connector.getUser(message.authorId).getOrElse(User(0, "unk.", false, "non existent user?", None, false, connector))
+    val user = connector.getUser(message.authorId).orElse(message.webhookID.map(id => User(0, s"Webhook $id", false, "some webhook", None, false, connector))).getOrElse(User(0, "unk.", false, "non existent user?", None, false, connector))
     val member = connector.getMember(message.authorId, message.channelId).getOrElse( 
       Member(user.id, selectedChannel.serverId.getOrElse(0), user.name, Seq.empty, 0, false, connector))
     chatList.addEntry(member, imagesCache(user.imageUrl.getOrElse("/red-questionmark.png")), message)

--- a/src/main/scala/discordccc/connector/DiscordConnector.scala
+++ b/src/main/scala/discordccc/connector/DiscordConnector.scala
@@ -415,6 +415,6 @@ class DiscordConnector(token: String, ahc: AsyncHttpClient) extends Connector wi
   }
   private def mapAttachments(attachments: Array[headache.Attachment]): Seq[Message.Attachment] = attachments.map(a => Message.Attachment(a.filename, a.url)) 
   private def mapMessage(m: headache.Message): Message = {
-    Message(m.id, mapContent(Option(m.content), m.embeds), m.timestamp, m.editedTimestamp, mapAttachments(m.attachments), m.channelId, m.author.id, this)
+    Message(m.id, mapContent(Option(m.content), m.embeds), m.timestamp, m.editedTimestamp, mapAttachments(m.attachments), m.channelId, m.author.id, this, m.webhookId)
   }
 }

--- a/src/main/scala/discordccc/connector/DiscordConnector.scala
+++ b/src/main/scala/discordccc/connector/DiscordConnector.scala
@@ -130,7 +130,7 @@ class DiscordConnector(token: String, ahc: AsyncHttpClient) extends Connector wi
     val serverId = channel.guildId
     val roles = guildUsersRoles.getOrDefault(serverId, emptyLongMap).getOrDefault(userId, noRoles)
     Member(userId, serverId, new String(guildUserNickname.getOrDefault(serverId, emptyLongMap).getOrDefault(userId, user.name)),
-           roles.map(_.name), roles.sortBy(_.position).find(_.color != 0).map(_.color).getOrElse(0),
+           roles.map(_.name), roles.sortBy(-_.position).find(_.color != 0).map(_.color).getOrElse(0),
            Option(guilds.get(serverId)).map(_.ownerId == userId).getOrElse(false), DiscordConnector.this)
   }
   def getMembers(channel: Channel): IndexedSeq[Member Either User] = {

--- a/src/main/scala/discordccc/connector/DiscordConnector.scala
+++ b/src/main/scala/discordccc/connector/DiscordConnector.scala
@@ -184,7 +184,7 @@ class DiscordConnector(token: String, ahc: AsyncHttpClient) extends Connector wi
             val user = allUsers.get(userId)
             val roles = guildUsersRoles.getOrDefault(serverId, emptyLongMap).getOrDefault(userId, noRoles)
             Left(Member(userId, serverId, new String(guildUserNickname.getOrDefault(serverId, emptyLongMap).getOrDefault(userId, user.name)),
-                        roles.map(_.name), roles.sortBy(_.position).find(_.color != 0).map(_.color).getOrElse(0),
+                        roles.map(_.name), roles.sortBy(-_.position).find(_.color != 0).map(_.color).getOrElse(0),
                         guilds.get(serverId).ownerId == userId, DiscordConnector.this))
           }
         }

--- a/src/main/scala/discordccc/model/chatModelEntities.scala
+++ b/src/main/scala/discordccc/model/chatModelEntities.scala
@@ -9,7 +9,7 @@ case class Channel(id: Long, serverId: Option[Long], name: String, topic: String
 case class Member(userId: Long, serverId: Long, nickname: String, roles: Seq[String], color: Int, isOwner: Boolean,
                   connector: Connector) extends ConnectorEntity
 case class Message(id: Long, content: Seq[Content], created: Instant, edited: Option[Instant], attachments: Seq[Message.Attachment],
-                   channelId: Long, authorId: Long, connector: Connector) extends ConnectorEntity {
+                   channelId: Long, authorId: Long, connector: Connector, webhookID: Option[String] = None) extends ConnectorEntity {
   def originalContent = content.map(_.originalText).mkString
 }
 object Message {


### PR DESCRIPTION
Webhook member names now show as Webhook $webhookID.

Role colours were being sorted by position. However, `sortBy` will sort in increasing order, and roles' positions have positive values. The fix to this was to negate the get: `roles.sortBy(_.position)` ➡`roles.sortBy(-_.position)`. Normally a `reverse` call on the `Ordering` would suffice, but the `position` property is numeric.